### PR TITLE
collector: Submit % with pct

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -81,6 +81,7 @@ func convertOutput(result [][]string) (metrics []metric, err error) {
 		res[0] = strings.Replace(res[0], "-", "_", -1)
 		res[0] = strings.Replace(res[0], ".", "_", -1)
 		res[0] = strings.Replace(res[0], "+", "p", -1)
+		res[0] = strings.Replace(res[0], "%", "pct", -1)
 
 		value, err = convertValue(res[1], res[2])
 		if err != nil {


### PR DESCRIPTION
`%` is not a valid character in a metric name for Prometheus but some hosts have sensors like `P1 Therm Ctrl %`. This would convert it to `P1 Therm Ctrl pct` which makes Prometheus happy. `pct` is the usual abbreviation of percent.
