### PR TITLE
Add replacement of '/' with '_' for metric names

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -81,6 +81,7 @@ func convertOutput(result [][]string) (metrics []metric, err error) {
 		res[0] = strings.Replace(res[0], "-", "_", -1)
 		res[0] = strings.Replace(res[0], ".", "_", -1)
 		res[0] = strings.Replace(res[0], "+", "p", -1)
+		res[0] = strings.Replace(res[0], "/", "_", -1)
 		res[0] = strings.Replace(res[0], "%", "pct", -1)
 
 		value, err = convertValue(res[1], res[2])


### PR DESCRIPTION
I tried to use the IPMI exporter, but encountered an error. Apparently it tried to create a metric description that contained the string "I/O". Since Prometheus does not allow the character "/" in metric names, I replaced it with an underscore.