### PR TITLE
Do not export raw metrics if reading failed

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -200,6 +200,7 @@ func (e *Exporter) collectRaws(ch chan<- prometheus.Metric) {
 				log.Infof("Error detected on quering %v. Disabling this sensor.", command[1])
 				rawSensors[i][3] = "disabled"
 				log.Errorln(err)
+				continue
 			}
 
 			results = append(results, []string{command[0], string(output), command[2]})


### PR DESCRIPTION
Most of the metrics are never exported if they cannot be read. This
extends this behaviour to the raw sensor values. This is useful for
situation where ipmitool fails, e.g. on most virtual machines. For
example the raw values would indicate a power supply failure, when
really this is not the case.