### PR TITLE
Fix parsing of hex output for supermicro raw commands

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/csv"
 	"encoding/hex"
+	"fmt"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -88,6 +89,10 @@ func convertOutput(result [][]string) (metrics []metric, err error) {
 	return metrics, err
 }
 
+func leftPadHexString(value string) string {
+	return fmt.Sprintf("%016v", value)
+}
+
 // Convert raw IPMI tool output to decimal numbers
 func convertRawOutput(result [][]string) (metrics []metric, err error) {
 	for _, res := range result {
@@ -97,11 +102,11 @@ func convertRawOutput(result [][]string) (metrics []metric, err error) {
 		for n := range res {
 			res[n] = strings.TrimSpace(res[n])
 		}
-		value, err := hex.DecodeString(res[1])
+		value, err := hex.DecodeString(leftPadHexString(res[1]))
 		if err != nil {
 			log.Errorf("could not parse ipmi output: %s", err)
 		}
-		r, _ := binary.Uvarint(value)
+		r := binary.BigEndian.Uint64(value)
 		currentMetric.value = float64(r)
 		currentMetric.unit = res[2]
 		currentMetric.metricsname = res[0]

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -24,3 +24,19 @@ func TestCollector(t *testing.T) {
 
 	fmt.Println(res)
 }
+
+func TestCollectRawOutput(t *testing.T) {
+	sampleResults := [][]string{
+		{"PSU2", "80", "W"}, // Hex value that is >= 0x80
+	}
+	res, err := convertRawOutput(sampleResults)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := float64(128)
+	if res[0].value != expected {
+		t.Fatalf("Expexted %f got %f", expected, res[0].value)
+	}
+}


### PR DESCRIPTION
Uvarint expects a protocol buffer bit format and when the value from
ipmitool is >= 0x80 Uvarint returns 0

So pad the hex string  with 0's to 8 bytes and use BigEndian.Uint64 for
converting to int